### PR TITLE
Add library category

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,30 @@
+{
+"name": "PZEM004T",
+"frameworks": "arduino",
+"keywords": "peacefair, pzem, powermeter",
+"description": "Enables communication with Peacefair PZEM-004T Energy monitor",
+"url": "https://github.com/olehs/PZEM004T",
+"authors": [
+    {
+        "name": "Oleg Sokolov"
+    }
+],
+"repository":
+{
+    "type": "git",
+    "url": "https://github.com/olehs/PZEM004T.git"
+},
+"platforms": [
+    "atmelavr",
+    "espressif8266"
+],
+"version": "1.0.0",
+"dependencies":
+[
+    {
+	"name": "EspSoftwareSerial",
+	"version": ">=3.2.0",
+	"platforms": "espressif8266"
+    }
+]
+}

--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,7 @@ author=Oleg Sokolov
 maintainer=
 sentence=Enables communication Peacefair PZEM-004T Energy monitor
 paragraph=
-url=
+category=Sensors
+url=https://github.com/olehs/PZEM004T
 architectures=avr
 


### PR DESCRIPTION
Adding category helps to get rid of "WARNING: Category '' in library PZEM004T is not valid. Setting to 'Uncategorized'" in arduino IDE.

library.json is a manifest file for PlatformIO, somewhat like 'library.properties' for arduino.