### PR TITLE
build-time flag to toggle softwareserial support

### DIFF
--- a/PZEM004T.h
+++ b/PZEM004T.h
@@ -7,7 +7,7 @@
 #include "WProgram.h"
 #endif
 
-#if not (defined(ESP32) || defined(ARDUINO_ARCH_ESP32))
+#if not (defined(ESP32) || defined(ARDUINO_ARCH_ESP32) || defined(PZEM004_NO_SWSERIAL))
 #define PZEM004_SOFTSERIAL
 #include <SoftwareSerial.h>
 #endif

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,6 +14,8 @@ power	KEYWORD2
 energy	KEYWORD2
 setAddress	KEYWORD2
 setPowerAlarm	KEYWORD2
+setReadTimeout	KEYWORD2
+readTimeout		KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
         "espressif8266",
         "expressif32"
     ],
-    "version": "1.1.0",
+    "version": "1.1.1",
     "dependencies": [
         {
             "name": "EspSoftwareSerial",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PZEM004T
-version=1.0
+version=1.1.1
 author=Oleg Sokolov
 maintainer=
 sentence=Enables communication to Peacefair PZEM-004T Energy monitor


### PR DESCRIPTION
For platforms where softserial is supported SoftwareSerial lib is always linked to the firmware even if not used in sketch at all, it would be nice to have a build-time flag that could disable it. 
Adding "-DPZEM004_NO_SWSERIAL" to build_flags completely disables SoftwareSerial lib
and saves some mcu resources. This could save up to 520/68/72 bytes of text/data/bss
mem for esp8266 platform.
