### PR TITLE
Replace usages of long with int32_t / uint32_t and make power()/energy() return int32_t

### DIFF
--- a/PZEM004T.cpp
+++ b/PZEM004T.cpp
@@ -46,7 +46,7 @@ PZEM004T::~PZEM004T()
         delete this->serial;
 }
 
-void PZEM004T::setReadTimeout(unsigned long msec)
+void PZEM004T::setReadTimeout(uint32_t msec)
 {
     _readTimeOut = msec;
 }
@@ -73,7 +73,7 @@ float PZEM004T::current(const IPAddress &addr)
     return (data[0] << 8) + data[1] + (data[2] / 100.0);
 }
 
-float PZEM004T::power(const IPAddress &addr)
+int32_t PZEM004T::power(const IPAddress &addr)
 {
     uint8_t data[RESPONSE_DATA_SIZE];
 
@@ -84,7 +84,7 @@ float PZEM004T::power(const IPAddress &addr)
     return (data[0] << 8) + data[1];
 }
 
-float PZEM004T::energy(const IPAddress &addr)
+int32_t PZEM004T::energy(const IPAddress &addr)
 {
     uint8_t data[RESPONSE_DATA_SIZE];
 
@@ -134,7 +134,7 @@ bool PZEM004T::recieve(uint8_t resp, uint8_t *data)
         ((SoftwareSerial *)serial)->listen();
 #endif
 
-    unsigned long startTime = millis();
+    uint32_t startTime = millis();
     uint8_t len = 0;
     while((len < RESPONSE_SIZE) && (millis() - startTime < _readTimeOut))
     {

--- a/PZEM004T.h
+++ b/PZEM004T.h
@@ -36,13 +36,13 @@ public:
     PZEM004T(HardwareSerial *port);
     ~PZEM004T();
 
-    void setReadTimeout(unsigned long msec);
-    unsigned long readTimeout() {return _readTimeOut;}
+    void setReadTimeout(uint32_t msec);
+    uint32_t readTimeout() {return _readTimeOut;}
 
     float voltage(const IPAddress &addr);
     float current(const IPAddress &addr);
-    float power(const IPAddress &addr);
-    float energy(const IPAddress &addr);
+    int32_t power(const IPAddress &addr);
+    int32_t energy(const IPAddress &addr);
 
     bool setAddress(const IPAddress &newAddr);
     bool setPowerAlarm(const IPAddress &addr, uint8_t threshold);
@@ -51,7 +51,7 @@ private:
     Stream *serial;
 
     bool _isSoft;
-    unsigned long _readTimeOut = PZEM_DEFAULT_READ_TIMEOUT;
+    uint32_t _readTimeOut = PZEM_DEFAULT_READ_TIMEOUT;
 
     void send(const IPAddress &addr, uint8_t cmd, uint8_t data = 0);
     bool recieve(uint8_t resp, uint8_t *data = 0);


### PR DESCRIPTION
Every other integer type is specified with intXX_t / uintXX_T, but the 32bit type is using "long", this should be changed so that it is consistent, and properly support potentially differing sizes on different platforms.

It also make sense to change the return types of the power() and energy() functions to return int32_t instead of float, they don't support decimal values.