### PR TITLE
Software Serial Instantiation

### DIFF
--- a/PZEM004T.cpp
+++ b/PZEM004T.cpp
@@ -33,6 +33,13 @@ PZEM004T::PZEM004T(uint8_t receivePin, uint8_t transmitPin)
 }
 #endif
 
+PZEM004T::PZEM004T(SoftwareSerial *port)
+{
+    port->begin(PZEM_BAUD_RATE);
+    this->serial = port;
+    this->_isSoft = true;
+}
+
 PZEM004T::PZEM004T(HardwareSerial *port)
 {
     port->begin(PZEM_BAUD_RATE);

--- a/PZEM004T.h
+++ b/PZEM004T.h
@@ -33,6 +33,7 @@ class PZEM004T
 {
 public:
     PZEM004T(uint8_t receivePin, uint8_t transmitPin);
+    PZEM004T(SoftWareSerial *port);
     PZEM004T(HardwareSerial *port);
     ~PZEM004T();
 

--- a/examples/ESP8266SoftwareSerial/ESP8266SoftwareSerial.ino
+++ b/examples/ESP8266SoftwareSerial/ESP8266SoftwareSerial.ino
@@ -1,0 +1,37 @@
+/*
+ * Simple example to show using the https://github.com/plerup/espsoftwareserial software 
+ * serial library on an ESP8266 with pins GPIO14 (RX) and GPIO12 (TX). 
+ */
+
+#include <SoftwareSerial.h> 
+#include <PZEM004T.h>
+
+SoftwareSerial swSer;  
+PZEM004T pzem(&swSer);      //Using https://github.com/plerup/espsoftwareserial library
+IPAddress ip(192,168,1,1);
+
+
+void setup() {
+  swSer.begin(9600, SWSERIAL_8N1, 14, 12, false, 95, 11);
+  Serial.begin(9600);
+  pzem.setAddress(ip);
+}
+
+void loop() {
+  float v = pzem.voltage(ip);
+  if (v < 0.0) v = 0.0;
+  Serial.print(v);Serial.print("V; ");
+
+  float i = pzem.current(ip);
+  if(i >= 0.0){ Serial.print(i);Serial.print("A; "); }
+  
+  float p = pzem.power(ip);
+  if(p >= 0.0){ Serial.print(p);Serial.print("W; "); }
+  
+  float e = pzem.energy(ip);
+  if(e >= 0.0){ Serial.print(e);Serial.print("Wh; "); }
+
+  Serial.println();
+
+  delay(1000);
+}


### PR DESCRIPTION
Hey, I couldn't make the existing software serial implementation work with an ESP8266 (which might have been something I was doing incorrectly). I noticed there is an ESP specific software serial library here: https://github.com/plerup/espsoftwareserial. I added instantiation methods for passing in a software serial object and an example. In general, I tried to get the hardware serial examples to work, but I had troubles (the RX pin pulling GPIO15 high is kind of a bummer). This seemed to me like the most straight forward way to talk to the PZEM004T and to be able to debug through the terminal. I think it might be useful for others as well. The example code works well; hopefully I haven't overlooked any other key functionality in the class. 