### PR TITLE
Remov SoftwareSerial from libdeps

### DIFF
--- a/library.json
+++ b/library.json
@@ -15,11 +15,4 @@
     },
     "platforms": "*",
     "version": "1.1.2",
-    "dependencies": [
-        {
-            "name": "EspSoftwareSerial",
-            "version": ">=3.2.0",
-            "platforms": "espressif8266"
-        }
-    ]
 }


### PR DESCRIPTION
SoftwareSerial is bundled into esp8266 Arduino framework.
plerup/espsoftwareserial repo contains dev version that might be not compatible with stable Core
