### PR TITLE
Constructor overload with custom pins for ESP32

### DIFF
--- a/PZEM004T.cpp
+++ b/PZEM004T.cpp
@@ -40,6 +40,22 @@ PZEM004T::PZEM004T(HardwareSerial *port)
     this->_isSoft = false;
 }
 
+/**
+ * @brief Hardware serial constructor with custom pin mapping (ESP32)
+ *
+ * @param port Hardware serial object (or port number as uint)
+ * @param rxpin gpio pin to map rx
+ * @param txpin gpio pin to map tx
+ */
+#ifdef ESP32
+PZEM004T::PZEM004T(HardwareSerial* port, uint8_t rxpin, uint8_t txpin){
+    port->begin(PZEM_BAUD_RATE, SERIAL_8N1, txpin, rxpin);
+    this->serial = port;
+    this->_isSoft = false;
+}
+#endif
+
+
 PZEM004T::~PZEM004T()
 {
 #ifdef PZEM004_SOFTSERIAL

--- a/PZEM004T.h
+++ b/PZEM004T.h
@@ -34,6 +34,17 @@ class PZEM004T
 public:
     PZEM004T(uint8_t receivePin, uint8_t transmitPin);
     PZEM004T(HardwareSerial *port);
+
+    /**
+     * @brief Hardware serial constructor with custom pin mapping (ESP32)
+     *
+     * @param port Hardware serial object (or port number as uint)
+     * @param rxpin gpio pin to map rx
+     * @param txpin gpio pin to map tx
+     */
+#ifdef ESP32
+    PZEM004T(HardwareSerial* port, uint8_t rxpin, uint8_t txpin);
+#endif
     ~PZEM004T();
 
     void setReadTimeout(unsigned long msec);

--- a/examples/PZEM_ESP32HwSerial/PZEM_ESP32HwSerial.ino
+++ b/examples/PZEM_ESP32HwSerial/PZEM_ESP32HwSerial.ino
@@ -7,6 +7,11 @@
 
 HardwareSerial PzemSerial2(2);     // Use hwserial UART2 at pins IO-16 (RX2) and IO-17 (TX2)
 PZEM004T pzem(&PzemSerial2);
+
+/*
+PZEM004T pzem(&PzemSerial2, 22, 23);  // Use hwserial UART2 remapped to custom pins IO-22 (RX) and IO-23 (TX)
+*/
+
 IPAddress ip(192,168,1,1);
 
 void setup() {


### PR DESCRIPTION
Allows to use hwserial on a non-default pins with ESP32