### PR TITLE
Fix swserial typo

### DIFF
--- a/PZEM004T.cpp
+++ b/PZEM004T.cpp
@@ -27,7 +27,7 @@
 PZEM004T::PZEM004T(uint8_t receivePin, uint8_t transmitPin)
 {
     SoftwareSerial *swserial = new SoftwareSerial(receivePin, transmitPin);
-    port->begin(PZEM_BAUD_RATE);
+    swserial->begin(PZEM_BAUD_RATE);
     this->serial = swserial;
     this->_isSoft = true;
 }


### PR DESCRIPTION
https://github.com/olehs/PZEM004T/commit/0debccb7221d75b44c11a43a3531dd7f9680bb00 changed the variable, but not the next statement

1.1.4 from the library registry will fail the build when swserial is enabled
```
/home/runner/.platformio/lib/PZEM004T/PZEM004T.cpp: In constructor 'PZEM004T::PZEM004T(uint8_t, uint8_t)':
/home/runner/.platformio/lib/PZEM004T/PZEM004T.cpp:30:5: error: 'port' was not declared in this scope
     port->begin(PZEM_BAUD_RATE);
     ^
*** [.pio/build/esp8266-4m-latest-base/lib678/PZEM004T/PZEM004T.cpp.o] Error 1
```